### PR TITLE
Added missing manufacturer names/ID numbers from AMEI Japan Group

### DIFF
--- a/Frameworks/SnoizeMIDI/en.lproj/ManufacturerNames.plist
+++ b/Frameworks/SnoizeMIDI/en.lproj/ManufacturerNames.plist
@@ -501,6 +501,14 @@
 	<key>004001</key><string>Softbank Mobile</string>
 	<key>004003</key><string>D&amp;M Holdings</string>
 	<key>004004</key><string>Xing</string>
-	<key>004005</key><string>Pioneer DJ</string>
+	<key>004005</key><string>AlphaTheta (Pioneer DJ)</string>
+	<key>004006</key><string>Pioneer</string>
+	<key>004007</key><string>Slik</string>
+	<key>004800</key><string>sigboost</string>
+	<key>004801</key><string>Lost Technology</string>
+	<key>004802</key><string>Uchiwa Fuujinn</string>
+	<key>004803</key><string>Tsukuba Science</string>
+	<key>004804</key><string>Sonicware</string>
+	<key>004805</key><string>Keshi Nomi Workshop</string>
 </dict>
 </plist>


### PR DESCRIPTION
[ Noticed when Sonicware wasn't recognized in SysEx Librarian. ]

Added missing manufacturer names for AMEI Japan:
Japan SysEx Manufacturers ID: http://www.amei.or.jp/report/report6.html
And more detail for 00 48 xx range: http://www.amei.or.jp//report/report7.html

	- Updated Pioneer DJ name to AlphaTheta (Pioneer DJ)
	- Added Pioneer, Silk in 00 40 xx range.
	- Added 00 48 xx range.
	  Details for 00 48 xx in report7 link.

Did not review and check the entire list, but did attempt reasonable translations of names (not trusting Google translate) and checking websites in report7 link. If there's ever a Japanese localization, then those links will be useful for Manufacturer names for the Japan Group ID numbers.

I also sent a note to the MIDI Association to request updating their list at:
https://www.midi.org/specifications-old/item/manufacturer-id-numbers